### PR TITLE
Add blur effect to history thumbnails

### DIFF
--- a/components/image-history-tray.tsx
+++ b/components/image-history-tray.tsx
@@ -127,7 +127,7 @@ export default function ImageHistoryTray({
 											"/placeholder.svg"
 										}
 										alt={latestEntryForStack.originalImageName || "Latest edit"}
-										className="h-full w-full object-cover rounded-md"
+										className="h-full w-full object-cover rounded-md blur-[2px]"
 									/>
 								) : (
 									<div className="h-full w-full flex items-center justify-center bg-muted rounded-md">
@@ -287,7 +287,7 @@ export default function ImageHistoryTray({
 															alt={
 																entry.originalImageName || `Edit ${entry.id}`
 															}
-															className="w-full h-full object-cover rounded-[0.2rem]"
+															className="w-full h-full object-cover rounded-[0.2rem] blur-[2px]"
 														/>
 													) : (
 														<div className="w-full h-full bg-muted flex items-center justify-center text-xs text-muted-foreground rounded-[0.2rem]">


### PR DESCRIPTION
## Summary
- add blur style to image thumbnails displayed in the history tray

## Testing
- `pnpm format`
- `pnpm lint` *(fails: "ELIFECYCLE Command failed with exit code 1" because Next.js lint configuration wizard runs)*

------
https://chatgpt.com/codex/tasks/task_b_684a8cf471bc8332bed3dc1030000c5e