### PR TITLE
Blur generated thumbnails

### DIFF
--- a/lib/image-utils.ts
+++ b/lib/image-utils.ts
@@ -35,6 +35,7 @@ export const createThumbnail = (
 				return reject(new Error("Failed to get canvas context for thumbnail"));
 			}
 
+			ctx.filter = "blur(1px)";
 			ctx.drawImage(img, 0, 0, width, height);
 			canvas.toBlob(
 				(blob) => {


### PR DESCRIPTION
## Summary
- blur the thumbnail output from `createThumbnail`

## Testing
- `npm run format`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_b_684a8fa1bf988332a24e26b3401e664b