### PR TITLE
Make clear all annotations undoable

### DIFF
--- a/components/annotation-canvas.tsx
+++ b/components/annotation-canvas.tsx
@@ -1022,7 +1022,7 @@ export default function AnnotationCanvas() {
 	};
 
 	const clearAllAnnotations = () => {
-		annotationHistory.reset([]);
+		annotationHistory.set([]);
 		setSelectedAnnotationId(null);
 	};
 


### PR DESCRIPTION
Make 'Clear All Annotations' undoable by adding it to the annotation history.