### PR TITLE
Add preset font choices

### DIFF
--- a/components/tool-settings.tsx
+++ b/components/tool-settings.tsx
@@ -12,12 +12,14 @@ import {
 import { Slider } from "@/components/ui/slider";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Separator } from "@/components/ui/separator";
+import { Type, Heading, Code } from "lucide-react";
 
 export interface ToolSettingsProps {
 	activeToolType: Tool | undefined;
@@ -257,6 +259,59 @@ export default function ToolSettings({
 								</TooltipTrigger>
 								<TooltipContent>Font Size</TooltipContent>
 							</Tooltip>
+							<div className="flex items-center gap-1">
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											variant={fontFamily === "Arial, sans-serif" ? "default" : "outline"}
+											size="sm"
+											className="h-8 w-8 p-0"
+											onClick={() => {
+												setFontFamily("Arial, sans-serif");
+												handleSettingChange("fontFamily", "Arial, sans-serif");
+											}}
+											aria-label="Sans-serif font"
+										>
+											<Type className="h-4 w-4" />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent>Sans-serif (Arial)</TooltipContent>
+								</Tooltip>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											variant={fontFamily === "Georgia, serif" ? "default" : "outline"}
+											size="sm"
+											className="h-8 w-8 p-0"
+											onClick={() => {
+												setFontFamily("Georgia, serif");
+												handleSettingChange("fontFamily", "Georgia, serif");
+											}}
+											aria-label="Serif font"
+										>
+											<Heading className="h-4 w-4" />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent>Serif (Georgia)</TooltipContent>
+								</Tooltip>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											variant={fontFamily === "Monaco, monospace" ? "default" : "outline"}
+											size="sm"
+											className="h-8 w-8 p-0"
+											onClick={() => {
+												setFontFamily("Monaco, monospace");
+												handleSettingChange("fontFamily", "Monaco, monospace");
+											}}
+											aria-label="Monospace font"
+										>
+											<Code className="h-4 w-4" />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent>Monospace (Monaco)</TooltipContent>
+								</Tooltip>
+							</div>
 							<Tooltip>
 								<TooltipTrigger asChild>
 									<Input


### PR DESCRIPTION
Add 3 font preset buttons to the text tool for quick selection of common font styles.

This PR introduces three buttons for Sans-serif (Arial), Serif (Georgia), and Monospace (Monaco) fonts, each with a relevant Lucide icon (Type, Heading, Code respectively). Users can still input custom font families.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-71e9d8fc-bd12-42ad-ac80-b114f04b6b60) · [Cursor](https://cursor.com/background-agent?bcId=bc-71e9d8fc-bd12-42ad-ac80-b114f04b6b60)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)